### PR TITLE
[REFACTOR] web-mobile 브릿지 타입 의존성 분리 및 멀티레포 대응 #2

### DIFF
--- a/src/bridge/types.ts
+++ b/src/bridge/types.ts
@@ -1,0 +1,100 @@
+// 웹-모바일 브릿지 공유 타입 (웹 자체 관리)
+// 모바일 bridge.ts 변경 시 이 파일도 함께 업데이트해야 합니다.
+
+// @webview-bridge/types 인라인 (외부 의존성 없이 타입만 정의)
+type _OnlyJSON<T> = {
+  [P in keyof T as T[P] extends string | number | boolean | null | undefined
+    ? P
+    : never]: T[P]
+}
+type _BridgeStore<T> = {
+  getState: () => T
+  setState: (newState: Partial<_OnlyJSON<T>>) => void
+  subscribe: (listener: (newState: T, prevState: T) => void) => () => void
+}
+
+// ─── 공유 데이터 타입 ────────────────────────────────────────────
+
+export type WatchHealthData = {
+  timestamp: number
+  heartRate: number
+  caloriesKcal: number
+  cadenceSpm: number   // Samsung Health SPM (모바일 가속도계보다 정확)
+  distanceM: number    // 만보계 기반 누적 거리(m)
+}
+
+export type GpsLocation = {
+  latitude: number
+  longitude: number
+  accuracy: number | null
+  altitude: number | null
+  heading: number | null
+  speedMps: number | null    // GPS Doppler 직접 측정값 (가속도계 추정보다 정확)
+  cadenceSpm: number | null  // 모바일 가속도계 기반 케이던스 (워치 SPM 대체)
+}
+
+export type VoiceCueKey =
+  | 'start_01'
+  | 'start_02'
+  | 'direction_left_100m'
+  | 'direction_left_70m'
+  | 'direction_left_50m'
+  | 'direction_left_30m'
+  | 'direction_left_10m'
+  | 'direction_right_100m'
+  | 'direction_right_70m'
+  | 'direction_right_50m'
+  | 'direction_right_30m'
+  | 'direction_right_10m'
+  | 'heart_rate_high_01'
+  | 'heart_rate_high_02'
+  | 'heart_rate_very_high_01'
+  | 'heart_rate_very_high_02'
+  | 'off_course_01'
+  | 'off_course_02'
+  | 'stable_back_01'
+  | 'stable_back_02'
+  | 'turnaround_01'
+  | 'turnaround_02'
+  | 'destination_01'
+  | 'destination_02'
+  | 'end_01'
+  | 'end_02'
+
+export type WatchRunMode = 'FREE' | 'COURSE' | 'GHOST'
+
+export type WatchLatLng = {
+  latitude: number
+  longitude: number
+}
+
+export type WatchRunStartPayload = {
+  runningSessionId: number
+  mode: WatchRunMode
+  courseCoordinates: WatchLatLng[]
+  ghostCoordinates: WatchLatLng[]
+}
+
+// ─── 브릿지 타입 (mobile bridge.ts와 동기화 필요) ────────────────
+
+type _AppBridgeMethods = {
+  whoRU(): Promise<string>
+  startSocialLogin(url: string): Promise<void>
+  notifyCourseDeviation(count: 1 | 2 | 3): Promise<void>
+  notifyCourseDeviationForceStop(): Promise<void>
+  playVoiceCue(key: VoiceCueKey): Promise<void>
+  stopVoiceCue(): Promise<void>
+  setVoiceEnabled(enabled: boolean): Promise<void>
+  startWatchRunSync(payload: WatchRunStartPayload): Promise<void>
+  stopWatchRunSync(): Promise<void>
+}
+
+// bridge() 반환 타입과 구조적으로 동일
+export type AppBridge = _BridgeStore<_AppBridgeMethods>
+
+// postMessageSchema() 반환 타입과 구조적으로 동일
+export type AndroidPostMessageSchema = {
+  watchMessage: { validate: (data: unknown) => { message: string } }
+  gpsLocation: { validate: (data: unknown) => GpsLocation }
+  watchHealthData: { validate: (data: unknown) => WatchHealthData }
+}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -29,8 +29,8 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"],
-      "@bridge": ["../mobile/src/bridge/types.ts"]
+      "@bridge": ["src/bridge/types.ts"]
     }
   },
-  "include": ["src", "../mobile/src/bridge/types.ts"]
+  "include": ["src"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
   resolve:{
     alias:{
       '@': path.resolve(__dirname, './src'),
-      '@bridge': path.resolve(__dirname, '../mobile/src/bridge/types.ts')
+      '@bridge': path.resolve(__dirname, './src/bridge/types.ts')
     }
   }
   


### PR DESCRIPTION
## 📌 요약 (What)
웹이 모바일 레포지토리의 브릿지 타입 파일(`mobile/src/bridge/types.ts`)을 직접 참조하던 구조를 제거하고,
웹 내부에 동일한 타입 정의 파일(`web/src/bridge/types.ts`)을 생성하여 자체 관리하도록 변경합니다.
이로써 모노레포에서 멀티레포로 전환 시 발생하는 web→mobile 타입 의존성을 완전히 제거합니다.


## 🎯 배경 / 이유 (Why)
기존에는 모바일과 웹이 같은 레포지토리를 공유하여, 웹의 `@bridge` alias가 `../mobile/src/bridge/types.ts`를
직접 가리키는 방식으로 타입을 공유했습니다.
멀티레포로 분리됨에 따라 해당 경로가 더 이상 유효하지 않으므로, 각 레포가 독립적으로 타입을 관리해야 합니다.


## 🛠 변경 사항 (How)
- `web/src/bridge/types.ts` 신규 생성: 모바일 types.ts를 기반으로 웹이 자체 관리하는 브릿지 타입 파일 추가
- `vite.config.ts`: `@bridge` alias 경로를 `../mobile/src/bridge/types.ts` → `./src/bridge/types.ts`로 변경
- `tsconfig.app.json`: `@bridge` paths 및 `include` 배열에서 mobile 폴더 외부 참조 제거


## 🔖 변경 유형 (Type of change)
- [ ] 🐛 Bug fix — 기존 동작을 정상화하는 변경
- [ ] ✨ New feature — 사용자에게 보이는 새로운 기능
- [x] ♻️ Refactor — 외부 동작 변화 없는 코드 구조 개선
- [ ] 📝 Documentation — 문서 변경
- [ ] 🎨 Style / Design — 코드 포맷 또는 사용자 UI 디자인 변경
- [ ] ✅ Test — 테스트 코드 추가/수정
- [ ] 🔧 Chore — 빌드, CI, 패키지 매니저 등 잡일
- [ ] ⚠️ BREAKING CHANGE — 호환성을 깨는 변경 (아래 영향 범위 섹션에 상세 기술)


## 🧪 검증 방법 (How Has This Been Tested?)

**자동화 테스트**
- 해당 없음 (타입 및 alias 설정 변경으로 런타임 동작 무변경)

**수동 검증**
1. `web` 디렉토리에서 `tsc --noEmit` 실행 후 타입 에러 없음 확인
2. `vite dev` 실행 후 `@bridge` import 정상 동작 확인
3. 브릿지 관련 기능(소셜 로그인, GPS, 워치 연동 등) 정상 동작 확인

**환경**
- OS: Windows 11
- Browser / Runtime: Chrome (WebView)
- Branch / Commit: 현재 브랜치


## 📸 스크린샷 / 데모
N/A


## ⚠️ 영향 범위 / 리스크
- [ ] DB 스키마 변경 / 마이그레이션 필요
- [ ] 환경변수 / 시크릿 추가/변경
- [ ] 외부 API 스펙 변경 (클라이언트 영향)
- [ ] 공용 컴포넌트 / 유틸 수정 (사용처 광범위)
- [ ] 인프라 / CI 설정 변경
- [ ] 성능에 영향 가능
- [x] 위 항목 모두 해당 없음

**상세:**
런타임 동작 변경 없음. 단, 향후 모바일 브릿지 인터페이스가 변경될 경우
`web/src/bridge/types.ts`를 수동으로 동기화해야 합니다.


## 🚀 머지 후 추가 작업
- [x] 없음 (단, 이후 모바일 브릿지 타입 변경 시 web types.ts 수동 동기화 필요)


## 🔗 관련 이슈 / 참고
- Resolves: #
- Ref: #


## 👀 리뷰어를 위한 안내
`web/src/bridge/types.ts`가 핵심 파일입니다.
`mobile/src/bridge/types.ts`와 타입이 동일한지 비교 확인해주세요.
나머지 변경(`vite.config.ts`, `tsconfig.app.json`)은 alias 경로 수정만 해당합니다.

> **향후 주의사항:** 모바일 팀이 브릿지 인터페이스를 변경하면 웹 팀에도 반드시 공유하여 이 파일을 동기화해야 합니다.


## ✅ 셀프 체크리스트
- [x] 제목이 `<type>(<scope>): <subject>` 형식이고 50~72자 이내
- [x] 본문에 "왜 이 변경이 필요한가"가 명시됨
- [x] 한 PR이 하나의 주제만 다룸 (분리하지 않은 이유가 있다면 본문에 설명됨)
- [ ] 관련 이슈가 본문에 링크됨
- [x] 새로 추가/변경한 동작에 대한 테스트가 있음 (없다면 그 이유가 본문에 설명됨)
- [ ] 로컬 또는 CI에서 테스트 통과 확인
- [x] DB 마이그레이션 / 환경변수 / 외부 의존성 등 후속 작업이 본문에 명시됨
- [x] UI 변경이라면 스크린샷 첨부
- [x] BREAKING CHANGE라면 영향 범위와 마이그레이션 방법 기술
- [ ] 리뷰어가 지정되어 있음
