### PR TITLE
[Feature] 웹 CI 및 Docker 배포 워크플로우 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,93 @@
+name: web-ci
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - dev
+      - main
+
+concurrency:
+  group: web-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    outputs:
+      image_tag: ${{ steps.meta.outputs.image_tag }}
+      should_deploy: ${{ steps.meta.outputs.should_deploy }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Test
+        run: pnpm test --if-present
+
+      - name: Build
+        run: pnpm build
+
+      - name: Set deploy metadata
+        id: meta
+        shell: bash
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF_NAME}" == "main" ]]; then
+            echo "should_deploy=true" >> "$GITHUB_OUTPUT"
+            echo "image_tag=main-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_deploy=false" >> "$GITHUB_OUTPUT"
+            echo "image_tag=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Docker Buildx
+        if: steps.meta.outputs.should_deploy == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        if: steps.meta.outputs.should_deploy == 'true'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push image
+        if: steps.meta.outputs.should_deploy == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/withrun-web:${{ steps.meta.outputs.image_tag }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/withrun-web:main
+
+  notify-infra:
+    if: needs.ci.outputs.should_deploy == 'true'
+    needs: ci
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger infra deploy
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.INFRA_REPO_DISPATCH_TOKEN }}
+          repository: with-run/infra
+          event-type: deploy-web
+          client-payload: >-
+            {"service":"web","image":"${{ secrets.DOCKERHUB_USERNAME }}/withrun-web:${{ needs.ci.outputs.image_tag }}","sha":"${{ github.sha }}","source_repo":"${{ github.repository }}"}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,14 +26,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.27.0
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'pnpm'
-
-      - name: Enable Corepack
-        run: corepack enable
 
       - name: Install
         run: pnpm install --frozen-lockfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ WORKDIR /app
 RUN ln -s /app/web/node_modules /app/node_modules
 
 COPY web ./web
-COPY mobile/src/bridge ./mobile/src/bridge
 
 WORKDIR /app/web
 ARG VITE_MODE=production


### PR DESCRIPTION
## Type of change
<!-- 해당하는 항목에 [x] 표시해주세요. 한 PR이 여러 유형에 해당한다면, 분리할 수 없는지 한 번 더 검토해보세요. -->
- [ ] 🐛 Bug fix — 기존 동작을 정상화하는 변경
- [ ] ✨ New feature — 사용자에게 보이는 새로운 기능
- [ ] ♻️ Refactor — 외부 동작 변화 없는 코드 구조 개선
- [ ] 📝 Documentation — 문서 변경
- [ ] 🎨 Style / Design — 코드 포맷 또는 사용자 UI 디자인 변경
- [ ] ✅ Test — 테스트 코드 추가/수정
- [X] 🔧 Chore — 빌드, CI, 패키지 매니저 등 잡일

## Motivation

웹 저장소 단독으로 빌드 검증과 배포 흐름을 자동화할 필요가 있어 GitHub Actions 기반 CI/CD를 추가했습니다.
추가로, 멀티레포 분리 이후에도 `web` 이미지 빌드 과정에서 `mobile/src/bridge`를 복사하던 Dockerfile 의존이 남아 있어 현재 저장소 구조에 맞게 정리했습니다.

## Problem Solving

- `push` / `pull_request` 기준으로 동작하는 웹 전용 GitHub Actions 워크플로우를 추가했습니다.
- CI에서 `pnpm install`, `test`, `build`를 수행하도록 구성했습니다.
- `main` 브랜치에 push 된 경우에만 Docker 이미지를 빌드하고 Docker Hub에 푸시하도록 설정했습니다.
- 이미지 푸시 이후 infra 저장소로 dispatch 이벤트를 보내 후속 배포가 가능하도록 연결했습니다.
- `Dockerfile`에서 `mobile/src/bridge` 복사 단계를 제거해 현재 repo 구조와 맞지 않는 경로 의존을 없앴습니다.

## To Reviewer

- 현재 PR은 웹 저장소 기준 CI/CD 파이프라인 추가와 Dockerfile 정리에 초점을 맞췄습니다.
- GitHub Actions에서 `main` push 시 이미지 빌드/푸시가 의도대로 동작하는지 중점적으로 봐주시면 됩니다.
- `VITE_MODE` 같은 빌드 인자 주입은 아직 workflow에 반영하지 않았기 때문에, 환경별 빌드가 필요하면 후속 반영이 필요합니다.
